### PR TITLE
[TDF] Remove redundant logic from tests

### DIFF
--- a/root/dataframe/regression_zeroentries.cxx
+++ b/root/dataframe/regression_zeroentries.cxx
@@ -18,54 +18,29 @@ int main() {
       t.Write();
    }
 
-   {
-      TFile f("regression_zeroentries.root");
-      ROOT::Experimental::TDataFrame d("emptyTree", &f, {"a"});
-
-      // apply all actions to an empty tree, single-threaded case
-      auto min = d.Min();
-      auto max = d.Max();
-      auto mean = d.Mean();
-      auto h = d.Histo1D();
-      auto c = d.Count();
-      auto g = d.Take<int>();
-      int fc = 0;
-      d.Foreach([&fc]() { ++fc; });
-
-      assert(*min == std::numeric_limits<double>::max());
-      assert(*max == std::numeric_limits<double>::min());
-      assert(*mean == 0);
-      assert(h->GetEntries() == 0);
-      assert(*c == 0);
-      assert(g->size() == 0);
-      assert(fc == 0);
-   }
-
-   {
 #ifdef R__USE_IMT
-      ROOT::EnableImplicitMT();
+   ROOT::EnableImplicitMT();
 #endif
-      TFile f("regression_zeroentries.root");
-      ROOT::Experimental::TDataFrame d("emptyTree", &f, {"a"});
+   TFile f("regression_zeroentries.root");
+   ROOT::Experimental::TDataFrame d("emptyTree", &f, {"a"});
 
-      // apply all actions to an empty tree, multi-thread case
-      auto min = d.Min();
-      auto max = d.Max();
-      auto mean = d.Mean();
-      auto h = d.Histo1D();
-      auto c = d.Count();
-      auto g = d.Take<int>();
-      std::atomic_int fc(0);
-      d.Foreach([&fc]() { ++fc; });
+   // apply all actions to an empty tree, multi-thread case
+   auto min = d.Min<int>();
+   auto max = d.Max<int>();
+   auto mean = d.Mean<int>();
+   auto h = d.Histo1D<int>();
+   auto c = d.Count();
+   auto g = d.Take<int>();
+   std::atomic_int fc(0);
+   d.Foreach([&fc]() { ++fc; });
 
-      assert(*min == std::numeric_limits<double>::max());
-      assert(*max == std::numeric_limits<double>::min());
-      assert(*mean == 0);
-      assert(h->GetEntries() == 0);
-      assert(*c == 0);
-      assert(g->size() == 0);
-      assert(fc == 0);
-   }
+   assert(*min == std::numeric_limits<double>::max());
+   assert(*max == std::numeric_limits<double>::min());
+   assert(*mean == 0);
+   assert(h->GetEntries() == 0);
+   assert(*c == 0);
+   assert(g->size() == 0);
+   assert(fc == 0);
 
    return 0;
 }

--- a/root/dataframe/test_foreach.ref
+++ b/root/dataframe/test_foreach.ref
@@ -1,2 +1,1 @@
-rms single-thread: 0.577346
-rms multi-thread: 0.577346
+rms: 0.577346

--- a/root/dataframe/test_reports.ref
+++ b/root/dataframe/test_reports.ref
@@ -1,7 +1,4 @@
 Info in <TDataFrame::Report>: Warning: the event-loop has not been run yet, all reports are empty
-stnoop    : pass=100000     all=100000     --  100.000 %
-stf       : pass=94999      all=100000     --   94.999 %
-Info in <TDataFrame::Report>: Warning: the event-loop has not been run yet, all reports are empty
 mtf       : pass=100        all=100000     --    0.100 %
 mtnoop    : pass=100        all=100        --  100.000 %
 mtf       : pass=0          all=0          --    0.000 %


### PR DESCRIPTION
Now that all tests are executed with and without implicit mt activated, there is no need to test both cases separately (the upcoming `testIMT` will take care of that case explicitly).