### PR TITLE
[TDF] Add test_callables

### DIFF
--- a/root/dataframe/CMakeLists.txt
+++ b/root/dataframe/CMakeLists.txt
@@ -7,6 +7,12 @@ endif()
 
 set(DFLIBRARIES Core TreePlayer Hist Tree RIO MathCore)
 
+ROOTTEST_GENERATE_EXECUTABLE(test_callables test_callables.cxx LIBRARIES ${DFLIBRARIES})
+ROOTTEST_ADD_TEST(test_callables
+                  EXEC test_callables
+                  OUTREF test_callables.ref
+                  DEPENDS ${GENERATE_EXECUTABLE_TEST})
+
 ROOTTEST_GENERATE_EXECUTABLE(testIMT testIMT.cxx LIBRARIES ${DFLIBRARIES})
 ROOTTEST_ADD_TEST(testIMT
                   EXEC testIMT

--- a/root/dataframe/test_callables.cxx
+++ b/root/dataframe/test_callables.cxx
@@ -1,0 +1,112 @@
+#include "ROOT/TDataFrame.hxx"
+#include "TFile.h"
+#include "TTree.h"
+#include "TError.h"
+#include <atomic>
+
+// Test support to different callable types:
+// free functions, functor classes, lambdas and std::functions are used
+// as filters, temporary branch expressions and foreach expressions.
+// Usage of these callables is sprinkled with std::moves.
+
+void FillTree(const char* filename, const char* treeName) {
+   TFile f(filename, "RECREATE");
+   TTree t(treeName, treeName);
+   double b;
+   t.Branch("b", &b);
+   for(int i = 0; i < 100000; ++i) {
+      b = i / 100000.;
+      t.Fill();
+   }
+   t.Write();
+   f.Close();
+}
+
+bool freeFilter(double) {
+   return true;
+}
+
+int freeBranch() {
+   return 42;
+}
+
+std::atomic_int freeCounter(0);
+void freeForeach(double) {
+   ++freeCounter;
+}
+
+class FunctorFilter {
+public:
+   bool operator()(double) {
+      return true;
+   }
+};
+
+class FunctorBranch {
+public:
+   int operator()() {
+      return 42;
+   }
+};
+
+class FunctorForeach {
+   static std::atomic_int fCounter;
+public:
+   void operator()(double) {
+      ++fCounter;
+   }
+   int GetCounter() const {
+      return fCounter;
+   }
+};
+std::atomic_int FunctorForeach::fCounter(0);
+
+int main(int argc, char** argv) {
+   auto fileName = "test_callables.root";
+   auto treeName = "callablesTree";
+   FillTree(fileName, treeName);
+   
+   TFile f("test_callables.root");
+   ROOT::Experimental::TDataFrame d("callablesTree", &f, {"b"});
+
+   // free function
+   d.Filter(freeFilter)
+    .AddBranch("a", freeBranch, {})
+    .Foreach(freeForeach); // this in turn calls ForeachSlot
+
+   // functor
+   FunctorFilter ff;
+   FunctorForeach fff;
+   d.Filter(ff)
+    .AddBranch("c", FunctorBranch())
+    .ForeachSlot(std::move(fff));
+
+   // lambda
+   auto filt = [](double b) { return true; };
+   auto branch = []() { return 42; };
+   std::atomic_int counter(0);
+   auto foreach = [&counter](double b) { ++counter; };
+   d.Filter(filt)
+    .AddBranch("d", std::move(branch), {})
+    .Foreach(foreach);
+
+   // std::function
+   std::function<bool(double)> stdfilt = filt;
+   std::function<int(void)> stdbranch = branch;
+   std::function<void(double)> stdforeach = foreach;
+   d.Filter(std::move(stdfilt))
+    .AddBranch("e", std::move(stdbranch), {})
+    .Foreach(foreach);
+
+   if (freeCounter == fff.GetCounter() && freeCounter*2 == counter
+       && freeCounter == static_cast<TTree*>(f.Get("callablesTree"))->GetEntries())
+      Info("test_callables", "alright");
+   else
+      Error("test_callables",
+            "not alright: %i %i %i",
+            static_cast<int>(freeCounter),
+            static_cast<int>(fff.GetCounter()),
+            static_cast<int>(counter));
+
+   return 0;
+}

--- a/root/dataframe/test_callables.ref
+++ b/root/dataframe/test_callables.ref
@@ -1,0 +1,1 @@
+Info in <test_callables>: alright


### PR DESCRIPTION
This test verifies we support different callable types:
free functions, functor classes, lambdas and std::functions are used
as filters, temporary branch expressions and foreach expressions.
Usage of these callables is sprinkled with std::move's.