### PR TITLE
[TDF] add test_reduce

### DIFF
--- a/root/dataframe/CMakeLists.txt
+++ b/root/dataframe/CMakeLists.txt
@@ -7,6 +7,10 @@ endif()
 
 set(DFLIBRARIES Core TreePlayer Hist Tree RIO MathCore)
 
+ROOTTEST_ADD_TEST(test_reduce
+                  MACRO test_reduce.C+
+                  OUTREF test_reduce.ref)
+
 ROOTTEST_GENERATE_EXECUTABLE(test_callables test_callables.cxx LIBRARIES ${DFLIBRARIES})
 ROOTTEST_ADD_TEST(test_callables
                   EXEC test_callables

--- a/root/dataframe/test_reduce.C
+++ b/root/dataframe/test_reduce.C
@@ -1,0 +1,37 @@
+#include "ROOT/TDataFrame.hxx"
+#include "TError.h" // Info
+#include "TFile.h"
+#include "TTree.h"
+
+void FillTree(const char* filename, const char* treeName) {
+   TFile f(filename, "RECREATE");
+   TTree t(treeName, treeName);
+   int i;
+   t.Branch("i", &i);
+   for(i = 1; i <= 10; ++i)
+      t.Fill();
+   t.Write();
+   f.Close();
+}
+
+void test_reduce() {
+   auto fileName = "test_reduce.root";
+   auto treeName = "reduceTree";
+   FillTree(fileName, treeName);
+
+#ifdef R__USE_IMT
+   ROOT::EnableImplicitMT();
+#endif
+   TFile f(fileName);
+   ROOT::Experimental::TDataFrame d("reduceTree", &f, {"i"});
+   auto r = d.Reduce([](int a, int b) { return a + b; }, {"i"});
+   auto rDefBranch = d.Filter([]() { return true; })
+                      .Reduce([](int a, int b) { return a*b; }, {}, 1);
+
+   Info("test_reduce", "%d %d", *r, *rDefBranch);
+}
+
+int main() {
+   test_reduce();
+   return 0;
+}

--- a/root/dataframe/test_reduce.ref
+++ b/root/dataframe/test_reduce.ref
@@ -1,0 +1,3 @@
+
+Processing test_reduce.cxx...
+Info in <test_reduce>: 55 3628800


### PR DESCRIPTION
`TDataFrame::Reduce` also supports branch types with no default constructor, but it seems that it was an overkill since it is not possible to have such objects in a `TTree`.