### PR TITLE
[DF] Add TreePlayer as an explicit dependency for tests

### DIFF
--- a/root/dataframe/CMakeLists.txt
+++ b/root/dataframe/CMakeLists.txt
@@ -7,7 +7,7 @@ if(ROOTTEST_OS_ID MATCHES Ubuntu)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-as-needed")
 endif()
 
-set(DFLIBRARIES Core ROOTDataFrame Hist Tree RIO MathCore)
+set(DFLIBRARIES Core RIO Hist Tree MathCore TreePlayer ROOTDataFrame)
 
 # ROOT-9628
 ROOTTEST_ADD_TEST(test_chainZombieFile


### PR DESCRIPTION
Otherwise, when building roottest against a pre-existing ROOT
installation, libTreePlayer is not linked.
This explicit dependency on libTreePlayer can be removed once the
ROOTDataFrame target transitively brings in its dependencies also
when building roottest against a pre-existing ROOT installation.