### PR TITLE
[cling] Add test against ROOT-5268 (disable runtime resolution for type names)

### DIFF
--- a/root/meta/CMakeLists.txt
+++ b/root/meta/CMakeLists.txt
@@ -18,6 +18,10 @@ ROOTTEST_ADD_TEST(clingTErrorDiagnostics
                   MACRO clingTErrorDiagnostics.C
                   OUTREF clingTErrorDiagnostics.ref)
 
+ROOTTEST_ADD_TEST(ROOT5268
+                  MACRO ROOT-5268.C
+                  PASSREGEX "error: unknown type name 'Tbrowser'")
+
 ROOTTEST_ADD_TEST(rlibmap
                   COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/rlibmapLauncher.py
                   PASSRC 1

--- a/root/meta/ROOT-5268.C
+++ b/root/meta/ROOT-5268.C
@@ -1,0 +1,3 @@
+{
+   Tbrowser a;
+}


### PR DESCRIPTION
Add test against [ROOT-5268](https://sft.its.cern.ch/jira/browse/ROOT-5268).

For more information, see the sibling PR in root: https://github.com/root-project/root/pull/9160.