### PR TITLE
stdpair: Fix building the test's library on MacOS.

### DIFF
--- a/root/io/stdpair/CMakeLists.txt
+++ b/root/io/stdpair/CMakeLists.txt
@@ -4,10 +4,10 @@ set(CMAKE_ROOTTEST_NOROOTMAP ON)
 set(RootExternalIncludes -e "gInterpreter->AddIncludePath(\"-I${CMAKE_CURRENT_SOURCE_DIR}\");")
 
 ROOT_GENERATE_DICTIONARY(G__CmsPairCollection ${CMAKE_CURRENT_SOURCE_DIR}/cmspair.h LINKDEF FullLinkDef.h)
-ROOTTEST_LINKER_LIBRARY(CmsPairCollection G__CmsPairCollection.cxx LIBRARIES ${ROOT_LIBRARIES})
+ROOTTEST_LINKER_LIBRARY(CmsPairCollection TEST G__CmsPairCollection.cxx LIBRARIES ${ROOT_LIBRARIES})
 
 ROOT_GENERATE_DICTIONARY(G__CmsPair ${CMAKE_CURRENT_SOURCE_DIR}/cmspair.h LINKDEF PairLinkDef.h)
-ROOTTEST_LINKER_LIBRARY(CmsPair G__CmsPair.cxx LIBRARIES ${ROOT_LIBRARIES})
+ROOTTEST_LINKER_LIBRARY(CmsPair TEST G__CmsPair.cxx LIBRARIES ${ROOT_LIBRARIES})
 
 ROOT_ADD_TEST(roottest-root-io-stdpair-collection-build 
               COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --config $<CONFIG> --target G__CmsPairCollection${fast}  CmsPairCollection${fast} -- ${always-make}


### PR DESCRIPTION
See also #858.

Note technically only one of the two commits:

a. Build libraries in the ROOT build step
b. Add explicit dependencies to correctly build the libraries when `ctest` is running

is needed to solve the problem.

Tests in `roottest` have been following those 2 distinct implementations (seemingly arbitrarily).  They require 2 different pattern of use to get things to work after changing files (related to 'libraries') in `roottest`:

1. `make && ctest`
or
2. just `ctest`

As we have it know, because several tests implement (a), we technically have to use pattern `1.` ; however if working on specific tests that implement (b) pattern `2.` might be sufficient.

In addition, when `runtime_cxxmodules` is ON, all tests supports *also* (a) **\*after\*** a second build directory configuration as their library is added indirectly to the `all` target by being added to the `module_idx` target (This is likely unintentional and explain why the problem solved by this PR was not seen in local development; it is not clear why it was not seen in the jenkings PR testing that introduced the test).

If we resolved to only use/support the implementation (a) we would gain by the removal of a set of `spurrious` tests (eg `roottest-root-io-stdpair-collection-build`) and thus likely reducing `ctest` run-time) but would lose support for pattern `2.`