### PR TITLE
[io] remove MathCore dependency from IoBigEventGeneration

### DIFF
--- a/root/io/bigevent/CMakeLists.txt
+++ b/root/io/bigevent/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 ROOTTEST_GENERATE_EXECUTABLE(IoBigEventGenerator
   ${CMAKE_CURRENT_SOURCE_DIR}/IoBigEventGenerator.cxx
   LIBRARIES Core RIO Net Tree Hist MathCore IoBigEventGeneration
-  DEPENDS IoBigEventGeneration MathCore
+  DEPENDS IoBigEventGeneration
   FIXTURES_SETUP io-bigevent-generator)
 
 ROOTTEST_ADD_TEST(write


### PR DESCRIPTION
It's not needed and it makes CMake fail to configure