### PR TITLE
Add auto_ptr schema evolution test

### DIFF
--- a/root/io/autoptr/CMakeLists.txt
+++ b/root/io/autoptr/CMakeLists.txt
@@ -1,0 +1,46 @@
+ROOTTEST_GENERATE_DICTIONARY(
+  event_v2_dict
+  ${CMAKE_CURRENT_SOURCE_DIR}/Event_v2.hxx
+  LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/Event_v2_LinkDef.h
+  NO_ROOTMAP NO_CXXMODULE
+  FIXTURES_SETUP generated_event_v2_dictionary
+)
+
+ROOTTEST_GENERATE_EXECUTABLE(
+  write_autoptr
+  LIBRARIES Core RIO Tree
+  FIXTURES_REQUIRED generated_event_v2_dictionary
+  FIXTURES_SETUP write_autoptr_excutable)
+
+target_sources(
+  write_autoptr
+  PRIVATE write_autoptr.cxx event_v2_dict.cxx
+)
+
+ROOTTEST_ADD_TEST(write_autoptr
+                  EXEC ./write_autoptr
+                  FIXTURES_REQUIRED write_autoptr_excutable
+                  FIXTURES_SETUP written_autoptr)
+
+ROOTTEST_GENERATE_DICTIONARY(
+  event_v3_dict
+  ${CMAKE_CURRENT_SOURCE_DIR}/Event_v3.hxx
+  LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/Event_v3_LinkDef.h
+  NO_ROOTMAP NO_CXXMODULE
+  FIXTURES_SETUP generated_event_v3_dictionary
+)
+
+ROOTTEST_GENERATE_EXECUTABLE(
+  evolve_autoptr
+  LIBRARIES Core RIO Tree
+  FIXTURES_REQUIRED generated_event_v3_dictionary
+  FIXTURES_SETUP evolve_autoptr_executable)
+
+target_sources(
+  evolve_autoptr
+  PRIVATE evolve_autoptr.cxx event_v3_dict.cxx
+)
+
+ROOTTEST_ADD_TEST(evolve_autoptr
+                  EXEC ./evolve_autoptr
+                  FIXTURES_REQUIRED evolve_autoptr_executable written_autoptr)

--- a/root/io/autoptr/Event_v2.hxx
+++ b/root/io/autoptr/Event_v2.hxx
@@ -1,0 +1,41 @@
+#ifndef EVENT_V2_H
+#define EVENT_V2_H
+
+#include <RtypesCore.h>
+
+#include <memory>
+
+// Since std::auto_ptr is deprecated and may not exist anymore, we emulate it.
+template <typename T>
+struct EmulatedAutoPtr {
+   T *fRawPtr = nullptr;
+
+   EmulatedAutoPtr() = default;
+   explicit EmulatedAutoPtr(T *rawPtr) : fRawPtr(rawPtr) {}
+   EmulatedAutoPtr &operator=(EmulatedAutoPtr &other)
+   {
+      fRawPtr = other.fRawPtr;
+      other.fRawPtr = nullptr;
+      return *this;
+   }
+   EmulatedAutoPtr &operator=(T *rawPtr)
+   {
+      fRawPtr = rawPtr;
+      return *this;
+   }
+};
+
+struct Track {
+   int fFoo;
+
+   ClassDefNV(Track, 2)
+};
+
+struct Event {
+   EmulatedAutoPtr<Track> fTrack;
+   float fBar = 137.0;
+
+   ClassDefNV(Event, 2)
+};
+
+#endif // EVENT_V2_H

--- a/root/io/autoptr/Event_v2_LinkDef.h
+++ b/root/io/autoptr/Event_v2_LinkDef.h
@@ -1,0 +1,7 @@
+#ifdef __ROOTCLING__
+
+#pragma link C++ class Track+;
+#pragma link C++ class Event+;
+#pragma link C++ class EmulatedAutoPtr<Track>+;
+
+#endif

--- a/root/io/autoptr/Event_v3.hxx
+++ b/root/io/autoptr/Event_v3.hxx
@@ -1,0 +1,35 @@
+#ifndef EVENT_V3_H
+#define EVENT_V3_H
+
+#include <RtypesCore.h>
+
+#include <memory>
+
+namespace Compat {
+
+template <typename T>
+struct DeprecatedAutoPtr
+{
+   // We use compat_auto_ptr only to assign the wrapped raw pointer to a unique pointer in an I/O customization rule.
+   // Therefore, we don't delete on destruction (because ownership gets transferred to the unique pointer).
+   // ~DeprecatedAutoPtr() { delete fRawPtr; }
+
+   T *fRawPtr = nullptr;
+};
+
+} // namespace Compat
+
+struct Track {
+   int fFoo;
+
+   ClassDefNV(Track, 2)
+};
+
+struct Event {
+   std::unique_ptr<Track> fTrack;
+   float fBar = 137.0;
+
+   ClassDefNV(Event, 3)
+};
+
+#endif // EVENT_V3_H

--- a/root/io/autoptr/Event_v3_LinkDef.h
+++ b/root/io/autoptr/Event_v3_LinkDef.h
@@ -1,0 +1,13 @@
+#ifdef __ROOTCLING__
+
+#pragma link C++ class Track+;
+#pragma link C++ class Event+;
+#pragma link C++ class Compat::DeprecatedAutoPtr<Track>+;
+
+#pragma read sourceClass="EmulatedAutoPtr<Track>" targetClass="Compat::DeprecatedAutoPtr<Track>"
+
+#pragma read sourceClass="Event" targetClass="Event" version="[2]" \
+  source="Compat::DeprecatedAutoPtr<Track> fTrack" target="fTrack" \
+  code="{ fTrack.release(); fTrack.reset(onfile.fTrack.fRawPtr); }"
+
+#endif

--- a/root/io/autoptr/evolve_autoptr.cxx
+++ b/root/io/autoptr/evolve_autoptr.cxx
@@ -1,0 +1,29 @@
+#include <TFile.h>
+#include <TTree.h>
+
+#include <memory>
+
+#include "Event_v3.hxx"
+
+int main()
+{
+   auto f = std::unique_ptr<TFile>(TFile::Open("root_test_autoptr.root"));
+   auto t = (TTree *)f->Get("t");
+
+   Event *event = nullptr;
+   t->SetBranchAddress("event", &event);
+
+   t->GetEntry(0);
+   if (!event->fTrack || event->fTrack->fFoo != 1)
+      return 1;
+
+   t->GetEntry(1);
+   if (event->fTrack)
+      return 2;
+
+   t->GetEntry(2);
+   if (!event->fTrack || event->fTrack->fFoo != 3)
+      return 3;
+
+   return 0;
+}

--- a/root/io/autoptr/write_autoptr.cxx
+++ b/root/io/autoptr/write_autoptr.cxx
@@ -1,0 +1,32 @@
+#include <TFile.h>
+#include <TTree.h>
+
+#include <memory>
+
+#include "Event_v2.hxx"
+
+int main()
+{
+   auto f = std::unique_ptr<TFile>(TFile::Open("root_test_autoptr.root", "RECREATE"));
+   auto t = new TTree("t", "");
+
+   Event event;
+   t->Branch("event", &event);
+
+   event.fTrack = new Track{1};
+   t->Fill();
+   delete event.fTrack.fRawPtr;
+
+   event.fTrack = nullptr;
+   t->Fill();
+   delete event.fTrack.fRawPtr;
+
+   event.fTrack = new Track{3};
+   t->Fill();
+   delete event.fTrack.fRawPtr;
+
+   t->Write();
+   f->Close();
+
+   return 0;
+}


### PR DESCRIPTION
Test evolution of auto_ptr into unique_ptr as a split member. Uses an emulated auto_ptr class instead of the real std::auto_ptr because the actual one may have been removed.

Tests the fix of PR #18320. I checked that without that fix, the test fails.