### PR TITLE
[v6-36][cmake] Use the `ROOT::Lib` syntax

### DIFF
--- a/root/io/bigevent/CMakeLists.txt
+++ b/root/io/bigevent/CMakeLists.txt
@@ -5,7 +5,7 @@ ROOT_GENERATE_DICTIONARY(G__IoBigEventGeneration
 ROOT_LINKER_LIBRARY(IoBigEventGeneration
   ${CMAKE_CURRENT_SOURCE_DIR}/IoBigEventGeneration.cxx
   G__IoBigEventGeneration.cxx
-  LIBRARIES Core Tree Hist MathCore Physics Graf Matrix)
+  LIBRARIES ROOT::Core ROOT::Tree ROOT::Hist ROOT::MathCore ROOT::Physics ROOT::Graf ROOT::Matrix)
 
 if(MSVC)
   add_custom_command(TARGET IoBigEventGeneration POST_BUILD

--- a/root/io/bigevent/CMakeLists.txt
+++ b/root/io/bigevent/CMakeLists.txt
@@ -1,19 +1,16 @@
 ROOT_GENERATE_DICTIONARY(G__IoBigEventGeneration
   ${CMAKE_CURRENT_SOURCE_DIR}/Event.h
-  LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/EventLinkDef.h
-  FIXTURES_SETUP io-bigevent-G__IoBigEventGeneration-fixture)
+  LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/EventLinkDef.h)
 
 ROOTTEST_LINKER_LIBRARY(IoBigEventGeneration
   ${CMAKE_CURRENT_SOURCE_DIR}/IoBigEventGeneration.cxx
-  TEST G__IoBigEventGeneration.cxx
-  LIBRARIES ROOT::Core ROOT::Tree ROOT::Hist ROOT::MathCore ROOT::Physics ROOT::Graf ROOT::Matrix
-  FIXTURES_REQUIRED io-bigevent-G__IoBigEventGeneration-fixture
-  FIXTURES_SETUP io-bigevent-references-IoBigEventGeneration-fixture)
+  G__IoBigEventGeneration.cxx
+  LIBRARIES ROOT::Core ROOT::Tree ROOT::Hist ROOT::MathCore ROOT::Physics ROOT::Graf ROOT::Matrix)
 
 ROOTTEST_GENERATE_EXECUTABLE(IoBigEventGenerator
   ${CMAKE_CURRENT_SOURCE_DIR}/IoBigEventGenerator.cxx
-  LIBRARIES Core RIO Net Tree Hist MathCore IoBigEventGeneration
-  FIXTURES_REQUIRED io-bigevent-references-IoBigEventGeneration-fixture
+  LIBRARIES ROOT::Core ROOT::RIO ROOT::Net ROOT::Tree ROOT::Hist ROOT::MathCore IoBigEventGeneration
+  DEPENDS IoBigEventGeneration
   FIXTURES_SETUP io-bigevent-generator)
 
 ROOTTEST_ADD_TEST(write

--- a/root/io/bigevent/CMakeLists.txt
+++ b/root/io/bigevent/CMakeLists.txt
@@ -4,7 +4,7 @@ ROOT_GENERATE_DICTIONARY(G__IoBigEventGeneration
 
 ROOT_LINKER_LIBRARY(IoBigEventGeneration
   ${CMAKE_CURRENT_SOURCE_DIR}/IoBigEventGeneration.cxx
-  G__IoBigEventGeneration.cxx
+  TEST G__IoBigEventGeneration.cxx
   LIBRARIES ROOT::Core ROOT::Tree ROOT::Hist ROOT::MathCore ROOT::Physics ROOT::Graf ROOT::Matrix)
 
 if(MSVC)

--- a/root/io/bigevent/CMakeLists.txt
+++ b/root/io/bigevent/CMakeLists.txt
@@ -1,24 +1,19 @@
 ROOT_GENERATE_DICTIONARY(G__IoBigEventGeneration
   ${CMAKE_CURRENT_SOURCE_DIR}/Event.h
-  LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/EventLinkDef.h)
+  LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/EventLinkDef.h
+  FIXTURES_SETUP io-bigevent-G__IoBigEventGeneration-fixture)
 
-ROOT_LINKER_LIBRARY(IoBigEventGeneration
+ROOTTEST_LINKER_LIBRARY(IoBigEventGeneration
   ${CMAKE_CURRENT_SOURCE_DIR}/IoBigEventGeneration.cxx
-  G__IoBigEventGeneration.cxx
-  LIBRARIES ROOT::Core ROOT::Tree ROOT::Hist ROOT::MathCore ROOT::Physics ROOT::Graf ROOT::Matrix)
-
-if(MSVC)
-  add_custom_command(TARGET IoBigEventGeneration POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/libIoBigEventGeneration.dll
-                                     ${CMAKE_CURRENT_BINARY_DIR}/libIoBigEventGeneration.dll
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/libIoBigEventGeneration.lib
-                                     ${CMAKE_CURRENT_BINARY_DIR}/libIoBigEventGeneration.lib)
-endif()
+  TEST G__IoBigEventGeneration.cxx
+  LIBRARIES ROOT::Core ROOT::Tree ROOT::Hist ROOT::MathCore ROOT::Physics ROOT::Graf ROOT::Matrix
+  FIXTURES_REQUIRED io-bigevent-G__IoBigEventGeneration-fixture
+  FIXTURES_SETUP io-bigevent-references-IoBigEventGeneration-fixture)
 
 ROOTTEST_GENERATE_EXECUTABLE(IoBigEventGenerator
   ${CMAKE_CURRENT_SOURCE_DIR}/IoBigEventGenerator.cxx
   LIBRARIES Core RIO Net Tree Hist MathCore IoBigEventGeneration
-  DEPENDS IoBigEventGeneration
+  FIXTURES_REQUIRED io-bigevent-references-IoBigEventGeneration-fixture
   FIXTURES_SETUP io-bigevent-generator)
 
 ROOTTEST_ADD_TEST(write

--- a/root/io/bigevent/CMakeLists.txt
+++ b/root/io/bigevent/CMakeLists.txt
@@ -4,7 +4,7 @@ ROOT_GENERATE_DICTIONARY(G__IoBigEventGeneration
 
 ROOT_LINKER_LIBRARY(IoBigEventGeneration
   ${CMAKE_CURRENT_SOURCE_DIR}/IoBigEventGeneration.cxx
-  TEST G__IoBigEventGeneration.cxx
+  G__IoBigEventGeneration.cxx
   LIBRARIES ROOT::Core ROOT::Tree ROOT::Hist ROOT::MathCore ROOT::Physics ROOT::Graf ROOT::Matrix)
 
 if(MSVC)

--- a/root/treeformula/references/CMakeLists.txt
+++ b/root/treeformula/references/CMakeLists.txt
@@ -5,7 +5,7 @@ ROOT_GENERATE_DICTIONARY(G__TreeFormulaReferencesGeneration
 ROOT_LINKER_LIBRARY(TreeFormulaReferencesGeneration
   ${CMAKE_CURRENT_SOURCE_DIR}/TreeFormulaReferencesGeneration.cxx
   G__TreeFormulaReferencesGeneration.cxx
-  LIBRARIES Core Tree Hist MathCore)
+  LIBRARIES ROOT::Core ROOT::Tree ROOT::Hist ROOT::MathCore)
 
 if(MSVC)
   add_custom_command(TARGET TreeFormulaReferencesGeneration POST_BUILD

--- a/root/treeformula/references/CMakeLists.txt
+++ b/root/treeformula/references/CMakeLists.txt
@@ -4,7 +4,7 @@ ROOT_GENERATE_DICTIONARY(G__TreeFormulaReferencesGeneration
 
 ROOT_LINKER_LIBRARY(TreeFormulaReferencesGeneration
   ${CMAKE_CURRENT_SOURCE_DIR}/TreeFormulaReferencesGeneration.cxx
-  TEST G__TreeFormulaReferencesGeneration.cxx
+  G__TreeFormulaReferencesGeneration.cxx
   LIBRARIES ROOT::Core ROOT::Tree ROOT::Hist ROOT::MathCore)
 
 if(MSVC)

--- a/root/treeformula/references/CMakeLists.txt
+++ b/root/treeformula/references/CMakeLists.txt
@@ -4,7 +4,7 @@ ROOT_GENERATE_DICTIONARY(G__TreeFormulaReferencesGeneration
 
 ROOTTEST_LINKER_LIBRARY(TreeFormulaReferencesGeneration
   ${CMAKE_CURRENT_SOURCE_DIR}/TreeFormulaReferencesGeneration.cxx
-  TEST G__TreeFormulaReferencesGeneration.cxx
+  G__TreeFormulaReferencesGeneration.cxx
   LIBRARIES ROOT::Core ROOT::Tree ROOT::Hist ROOT::MathCore)
 
 ROOTTEST_GENERATE_EXECUTABLE(TreeFormulaReferencesGenerator

--- a/root/treeformula/references/CMakeLists.txt
+++ b/root/treeformula/references/CMakeLists.txt
@@ -4,7 +4,7 @@ ROOT_GENERATE_DICTIONARY(G__TreeFormulaReferencesGeneration
 
 ROOT_LINKER_LIBRARY(TreeFormulaReferencesGeneration
   ${CMAKE_CURRENT_SOURCE_DIR}/TreeFormulaReferencesGeneration.cxx
-  G__TreeFormulaReferencesGeneration.cxx
+  TEST G__TreeFormulaReferencesGeneration.cxx
   LIBRARIES ROOT::Core ROOT::Tree ROOT::Hist ROOT::MathCore)
 
 if(MSVC)

--- a/root/treeformula/references/CMakeLists.txt
+++ b/root/treeformula/references/CMakeLists.txt
@@ -1,19 +1,16 @@
 ROOT_GENERATE_DICTIONARY(G__TreeFormulaReferencesGeneration
   ${CMAKE_CURRENT_SOURCE_DIR}/Event.h
-  LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/EventLinkDef.h
-  FIXTURES_SETUP treeformula-references-G__TreeFormulaReferencesGeneration-fixture)
+  LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/EventLinkDef.h)
 
 ROOTTEST_LINKER_LIBRARY(TreeFormulaReferencesGeneration
   ${CMAKE_CURRENT_SOURCE_DIR}/TreeFormulaReferencesGeneration.cxx
   TEST G__TreeFormulaReferencesGeneration.cxx
-  LIBRARIES ROOT::Core ROOT::Tree ROOT::Hist ROOT::MathCore
-  FIXTURES_REQUIRED treeformula-references-G__TreeFormulaReferencesGeneration-fixture
-  FIXTURES_SETUP treeformula-references-TreeFormulaReferencesGeneration-fixture)
+  LIBRARIES ROOT::Core ROOT::Tree ROOT::Hist ROOT::MathCore)
 
 ROOTTEST_GENERATE_EXECUTABLE(TreeFormulaReferencesGenerator
   ${CMAKE_CURRENT_SOURCE_DIR}/TreeFormulaReferencesGenerator.cxx
-  LIBRARIES Core RIO Net Tree Hist MathCore TreeFormulaReferencesGeneration
-  FIXTURES_REQUIRED treeformula-references-TreeFormulaReferencesGeneration-fixture
+  LIBRARIES ROOT::Core ROOT::RIO ROOT::Net ROOT::Tree ROOT::Hist ROOT::MathCore TreeFormulaReferencesGeneration
+  DEPENDS TreeFormulaReferencesGeneration
   FIXTURES_SETUP treeformula-references-generator)
 
 set(size 6)

--- a/root/treeformula/references/CMakeLists.txt
+++ b/root/treeformula/references/CMakeLists.txt
@@ -1,24 +1,19 @@
 ROOT_GENERATE_DICTIONARY(G__TreeFormulaReferencesGeneration
   ${CMAKE_CURRENT_SOURCE_DIR}/Event.h
-  LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/EventLinkDef.h)
+  LINKDEF ${CMAKE_CURRENT_SOURCE_DIR}/EventLinkDef.h
+  FIXTURES_SETUP treeformula-references-G__TreeFormulaReferencesGeneration-fixture)
 
-ROOT_LINKER_LIBRARY(TreeFormulaReferencesGeneration
+ROOTTEST_LINKER_LIBRARY(TreeFormulaReferencesGeneration
   ${CMAKE_CURRENT_SOURCE_DIR}/TreeFormulaReferencesGeneration.cxx
-  G__TreeFormulaReferencesGeneration.cxx
-  LIBRARIES ROOT::Core ROOT::Tree ROOT::Hist ROOT::MathCore)
-
-if(MSVC)
-  add_custom_command(TARGET TreeFormulaReferencesGeneration POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/libTreeFormulaReferencesGeneration.dll
-                                     ${CMAKE_CURRENT_BINARY_DIR}/libTreeFormulaReferencesGeneration.dll
-    COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/libTreeFormulaReferencesGeneration.lib
-                                     ${CMAKE_CURRENT_BINARY_DIR}/libTreeFormulaReferencesGeneration.lib)
-endif()
+  TEST G__TreeFormulaReferencesGeneration.cxx
+  LIBRARIES ROOT::Core ROOT::Tree ROOT::Hist ROOT::MathCore
+  FIXTURES_REQUIRED treeformula-references-G__TreeFormulaReferencesGeneration-fixture
+  FIXTURES_SETUP treeformula-references-TreeFormulaReferencesGeneration-fixture)
 
 ROOTTEST_GENERATE_EXECUTABLE(TreeFormulaReferencesGenerator
   ${CMAKE_CURRENT_SOURCE_DIR}/TreeFormulaReferencesGenerator.cxx
   LIBRARIES Core RIO Net Tree Hist MathCore TreeFormulaReferencesGeneration
-  DEPENDS TreeFormulaReferencesGeneration
+  FIXTURES_REQUIRED treeformula-references-TreeFormulaReferencesGeneration-fixture
   FIXTURES_SETUP treeformula-references-generator)
 
 set(size 6)


### PR DESCRIPTION
Fixes an issue when building roottest with pre-built ROOT on Windows
[as reported on the forum](https://root-forum.cern.ch/t/windows-roottest-v6-36-00-patches-lnk1181-core-lib-issues-cea-45230/63762)