### PR TITLE
[cmake][win] Prevent checking libgen-build dependencies

### DIFF
--- a/cmake/modules/RoottestMacros.cmake
+++ b/cmake/modules/RoottestMacros.cmake
@@ -11,7 +11,7 @@ if(CMAKE_GENERATOR MATCHES Makefiles)
   set(always-make --always-make)
 endif()
 if(MSVC AND NOT CMAKE_GENERATOR MATCHES Ninja)
-  set(always-make -v:m)
+  set(always-make -v:m -clp:Summary -p:BuildProjectReferences=false)
 endif()
 #-------------------------------------------------------------------------------
 #


### PR DESCRIPTION
Prevent checking and linking the libgen-build tests dependencies (like LLVM)
make the libgen-build tests take 10-15 seconds instead of 60-120 seconds
(or even more sometimes)